### PR TITLE
Use /usr/bin/env in shebang.

### DIFF
--- a/disk/bitesize
+++ b/disk/bitesize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # bitesize - show disk I/O size as a histogram.
 #            Written using Linux perf_events (aka "perf").

--- a/execsnoop
+++ b/execsnoop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # execsnoop - trace process exec() with arguments.
 #             Written using Linux ftrace.

--- a/iolatency
+++ b/iolatency
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # iolatency - summarize block device I/O latency as a histogram.
 #             Written using Linux ftrace.

--- a/iosnoop
+++ b/iosnoop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # iosnoop - trace block device I/O.
 #           Written using Linux ftrace.

--- a/kernel/funccount
+++ b/kernel/funccount
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # funccount - count kernel function calls matching specified wildcards.
 #             Uses Linux ftrace.

--- a/kernel/funcgraph
+++ b/kernel/funcgraph
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # funcgraph - trace kernel function graph, showing child function calls.
 #             Uses Linux ftrace.

--- a/kernel/funcslower
+++ b/kernel/funcslower
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # funcslower - trace kernel functions slower than a threshold (microseconds).
 #              Uses Linux ftrace.

--- a/kernel/functrace
+++ b/kernel/functrace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # functrace - trace kernel function calls matching specified wildcards.
 #             Uses Linux ftrace.

--- a/kernel/kprobe
+++ b/kernel/kprobe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # kprobe - trace a given kprobe definition. Kernel dynamic tracing.
 #          Written using Linux ftrace.

--- a/misc/perf-stat-hist
+++ b/misc/perf-stat-hist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # perf-stat-hist - perf_events stat histogram hack.
 #                  Written using Linux perf_events (aka "perf").

--- a/net/tcpretrans
+++ b/net/tcpretrans
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # tcpretrans - show TCP retransmts, with address and other details.
 #              Written using Linux ftrace.

--- a/opensnoop
+++ b/opensnoop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # opensnoop - trace open() syscalls with file details.
 #             Written using Linux ftrace.

--- a/syscount
+++ b/syscount
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # syscount - count system calls.
 #            Written using Linux perf_events (aka "perf").

--- a/system/tpoint
+++ b/system/tpoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # tpoint - trace a given tracepoint. Static tracing.
 #          Written using Linux ftrace.

--- a/tools/reset-ftrace
+++ b/tools/reset-ftrace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # reset-ftrace - reset state of ftrace, disabling all tracing.
 #                Written for Linux ftrace.


### PR DESCRIPTION
On some distributions (e.g., NixOS) the bash binary is not in /bin/bash
and the perl binary not in /usr/bin/perl.  Using /usr/bin/env in the
shebag instead should make it work.
