### PR TITLE
killsnoop: can't work with mawk

### DIFF
--- a/killsnoop
+++ b/killsnoop
@@ -131,8 +131,11 @@ else
 fi
 
 ### select awk
-(( opt_duration )) && use=mawk || use=gawk  # workaround for mawk fflush()
-[[ -x /usr/bin/$use ]] && awk=$use || awk=awk
+# workaround for mawk fflush()
+[[ -x /usr/bin/mawk ]] && awk="mawk" && mawk -W interactive && \
+[ $? -eq 0 ] && awk="mawk -W interactive"
+# workaround for gawk strtonum()
+[[ -x /usr/bin/gawk ]] && awk="gawk --non-decimal-data"
 
 ### check permissions
 cd $tracing || die "ERROR: accessing tracing. Root user? Kernel has FTRACE?
@@ -219,15 +222,15 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
         signal = $(7+o)
         sub(/,$/, "", kpid)
         sub(/\)$/, "", signal)
-        kpid = strtonum("0x"kpid)
-        signal = strtonum("0x"signal)
+        kpid = int("0x"kpid)
+        signal = int("0x"signal)
         current[pid,"kpid"] = kpid
         current[pid,"signal"] = signal
     }
 
     # sys_kill exit
     $1 != "#" && $(5+o) ~ /->/ {
-        rv = strtonum($NF)
+        rv = int($NF)
         killed_pid = current[pid,"kpid"]
         signal = current[pid,"signal"]
 


### PR DESCRIPTION
On Ubuntu Linux release, mawk is used by default. This issue caused
killsnoop can't work on Ubuntu by default.

There are two issues,
    a. The strtonum is not supported by mawk.
       Try to use int to convert string to number.
       For gawk, int usage need the --non-decimal-data option.
       On very old RHEL release(2.6.18 kernel), the gawk can support
       this option.
    b. killsnoop still has no results due to mawk buffering porblems.
       Using -W interactive could solve this isue.
       The option is available on mawk 1.2, RHEL 4+ should support it.

Signed-off-by: Oliver Yang <yangoliver@gmail.com>