### PR TITLE
awk scirpt can't work if process name contains space

### DIFF
--- a/opensnoop
+++ b/opensnoop
@@ -207,12 +207,15 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
     -v opt_file=$opt_file -v file=$file '
 	# common fields
 	$1 != "#" {
-		# task name can contain dashes
-		comm = pid = $1
-		sub(/-[0-9][0-9]*/, "", comm)
+		# task name can contain dashes and space
+		split($0, line, "-")
+		sub(/^[ \t\r\n]+/, "", line[1])
+		comm = line[1]
 		if (opt_name && match(comm, name) == 0)
 			next
-		sub(/.*-/, "", pid)
+		pid = line[2]
+		split(pid, line, " ")
+		pid = line[1]
 	}
 
 	# do_sys_open()


### PR DESCRIPTION
Signed-off-by: Oliver Yang <yangoliver@gmail.com>

The process name could have space like below,

    dd_worker thr-26121 [010] 527660.712693: getnameprobe: (do_sys_open+0xe2/0x1b4 <- getname) arg1="/dev/sg95"
    dd_worker thr-26121 [010] 527660.712698: sys_open -> 0x4f

With the fix, the opensnoop can show the process correctly,

    # /ddr/bin/opensnoop -n dd_w
    Tracing open()s issued by process name "dd_w". Ctrl-C to end.
    COMM             PID      FD FILE
    dd_worker thr   26121  0x4f /dev/sg95
    dd_worker thr   26121  0x4f /dev/sg180