### PR TITLE
Replace split by sub to get pid

### DIFF
--- a/opensnoop
+++ b/opensnoop
@@ -213,9 +213,8 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
 		comm = line[1]
 		if (opt_name && match(comm, name) == 0)
 			next
+		sub(/ .*$/, "", line[2])
 		pid = line[2]
-		split(pid, line, " ")
-		pid = line[1]
 	}
 
 	# do_sys_open()


### PR DESCRIPTION
Signed-off-by: Oliver Yang <yangoliver@gmail.com>

Per Gregg's comments, use sub instead of split to get the pid.

Here is the test based on new changes,

    $ sudo ./opensnoop 
    Tracing open()s. Ctrl-C to end.
    COMM             PID      FD FILE
    opensnoop        8956    0x3 
    awk              8960    0x3 /etc/ld.so.cache
    awk              8960    0x3 /lib/x86_64-linux-gnu/libm.so.6
    awk              8960    0x3 /lib/x86_64-linux-gnu/libc.so.6
    cat              8961    0x3 /etc/ld.so.cache
    cat              8961    0x3 /lib/x86_64-linux-gnu/libc.so.6
    cat              8961    0x3 /usr/lib/locale/locale-archive
    cat              8961    0x3 trace_pipe
    vminfo           1284    0x5 /var/run/utmp
