### PR TITLE
ftrace scripts don't start tracing on Linux 3.13

### DIFF
--- a/opensnoop
+++ b/opensnoop
@@ -93,6 +93,7 @@ function end {
 	fi
 	warn "echo -:getnameprobe >> kprobe_events"
 	warn "echo > trace"
+	warn "echo 0 > tracing_on"
 	(( wroteflock )) && warn "rm $flock"
 }
 
@@ -172,6 +173,9 @@ if (( opt_pid )); then
 	then
 	    edie "ERROR: setting -p $pid. Exiting."
 	fi
+fi
+if ! echo 1 > tracing_on; then
+	edie "ERROR: enabling tracing. Exiting."
 fi
 if ! echo 1 > events/kprobes/getnameprobe/enable; then
 	edie "ERROR: enabling kprobe for getname(). Exiting."


### PR DESCRIPTION
On my system, none of the ftrace scripts print any output because they don't turn tracing on.

This change runs echo 1 > tracing_on before starting opensnoop.

This shouldn't be merged as-is since I haven't tested it with any other Linux kernel versions, and all the other ftrace scripts have the same problem and I haven't modified them, but this patch fixes the problem for me for opensnoop in case it's useful :)

My kernel version, from `uname -a`, is `3.13.0-43-generic #72~precise1-Ubuntu`