### PR TITLE
Use the ftrace buffer instances

### DIFF
--- a/execsnoop
+++ b/execsnoop
@@ -54,7 +54,11 @@
 # 07-Jul-2014	Brendan Gregg	Created this.
 
 ### default variables
-tracing=/sys/kernel/debug/tracing
+mkdir -p /sys/kernel/debug/tracing/instances/execsnoop
+echo context-info > /sys/kernel/debug/tracing/instances/execsnoop/trace_options
+tracing=/sys/kernel/debug/tracing/instances/execsnoop
+kprobe_events=/sys/kernel/debug/tracing/kprobe_events
+current_tracer=/sys/kernel/debug/tracing/current_tracer
 flock=/var/tmp/.ftrace-lock; wroteflock=0
 opt_duration=0; duration=; opt_name=0; name=; opt_time=0; opt_reexec=0
 opt_argc=0; argc=8; max_argc=16; ftext=
@@ -93,7 +97,7 @@ function end {
 	cd $tracing
 	warn "echo 0 > events/kprobes/$kname/enable"
 	warn "echo 0 > events/sched/sched_process_fork/enable"
-	warn "echo -:$kname >> kprobe_events"
+	warn "echo -:$kname >> $kprobe_events"
 	warn "echo > trace"
 	(( wroteflock )) && warn "rm $flock"
 }
@@ -188,12 +192,12 @@ function makeprobe {
 makeprobe sys_execve
 
 ### setup and begin tracing
-echo nop > current_tracer
-if ! echo $kprobe >> kprobe_events 2>/dev/null; then
+echo nop > $current_tracer
+if ! echo $kprobe >> $kprobe_events 2>/dev/null; then
 	makeprobe stub_execve
-	if ! echo $kprobe >> kprobe_events 2>/dev/null; then
+	if ! echo $kprobe >> $kprobe_events 2>/dev/null; then
 	    makeprobe do_execve
-	    if ! echo $kprobe >> kprobe_events 2>/dev/null; then
+	    if ! echo $kprobe >> $kprobe_events 2>/dev/null; then
 		    edie "ERROR: adding a kprobe for execve. Exiting."
         fi
 	fi

--- a/iolatency
+++ b/iolatency
@@ -40,7 +40,10 @@
 # 20-Jul-2014	Brendan Gregg	Created this.
 
 ### default variables
-tracing=/sys/kernel/debug/tracing
+mkdir -p /sys/kernel/debug/tracing/instances/execsnoop
+echo context-info > /sys/kernel/debug/tracing/instances/execsnoop/trace_options
+tracing=/sys/kernel/debug/tracing/instances/execsnoop
+current_tracer=/sys/kernel/debug/tracing/current_tracer
 flock=/var/tmp/.ftrace-lock
 bufsize_kb=4096
 opt_device=0; device=; opt_iotype=0; iotype=; opt_timestamp=0
@@ -148,7 +151,7 @@ echo $$ > $flock || die "ERROR: unable to write $flock."
 wroteflock=1
 
 ### setup and begin tracing
-warn "echo nop > current_tracer"
+warn "echo nop > $current_tracer"
 warn "echo $bufsize_kb > buffer_size_kb"
 filter=
 if (( opt_iotype )); then

--- a/iosnoop
+++ b/iosnoop
@@ -53,7 +53,10 @@
 # 12-Jul-2014	Brendan Gregg	Created this.
 
 ### default variables
-tracing=/sys/kernel/debug/tracing
+mkdir -p /sys/kernel/debug/tracing/instances/execsnoop
+echo context-info > /sys/kernel/debug/tracing/instances/execsnoop/trace_options
+tracing=/sys/kernel/debug/tracing/instances/execsnoop
+current_tracer=/sys/kernel/debug/tracing/current_tracer
 flock=/var/tmp/.ftrace-lock
 bufsize_kb=4096
 opt_duration=0; duration=; opt_name=0; name=; opt_pid=0; pid=; ftext=
@@ -177,7 +180,7 @@ cd $tracing || die "ERROR: accessing tracing. Root user? Kernel has FTRACE?
 echo $$ > $flock || die "ERROR: unable to write $flock."
 
 ### setup and begin tracing
-echo nop > current_tracer
+echo nop > $current_tracer
 warn "echo $bufsize_kb > buffer_size_kb"
 filter=
 if (( opt_iotype )); then

--- a/killsnoop
+++ b/killsnoop
@@ -48,7 +48,10 @@
 # 13-Sep-2014   Martin Probst   Created this.
 
 ### default variables
-tracing=/sys/kernel/debug/tracing
+mkdir -p /sys/kernel/debug/tracing/instances/execsnoop
+echo context-info > /sys/kernel/debug/tracing/instances/execsnoop/trace_options
+tracing=/sys/kernel/debug/tracing/instances/execsnoop
+current_tracer=/sys/kernel/debug/tracing/current_tracer
 flock=/var/tmp/.ftrace-lock; wroteflock=0
 opt_duration=0; duration=; opt_name=0; name=; opt_pid=0; pid=; ftext=
 opt_time=0; opt_fail=0; opt_file=0; file=
@@ -147,7 +150,7 @@ echo $$ > $flock || die "ERROR: unable to write $flock."
 wroteflock=1
 
 ### setup and begin tracing
-echo nop > current_tracer
+echo nop > $current_tracer
 if ! echo 1 > $kevent_entry/enable; then
     edie "ERROR: enabling kill() entry tracepoint Exiting."
 fi


### PR DESCRIPTION
If ftrace is already in use without instances, options are inherited and it prevents the logging to work as expected for the pertf-tools CLIs.

@brendangregg : It's a very simplistic approach to the problem, not sure you want to merge that like it, but it's mainly a heads up if some other people are running into the same issues as I did.
