### PR TITLE
Fix filter intended to exclude perf's own writes.

### DIFF
--- a/syscount
+++ b/syscount
@@ -144,7 +144,7 @@ if (( opt_count && opt_verbose )); then
 		tp=$(perf list syscalls:sys_enter_* | awk '
 		    $1 != "syscalls:sys_enter_write" &&  $1 ~ /syscalls:/ { printf "-e %s ", $1 }')
 		tp="$tp -e syscalls:sys_enter_write"
-		sh -c "perf record $tp --filter 'common_pid != '\$\$ $cpus $cmd"
+		sh -c "exec perf record $tp --filter 'common_pid != '\$\$ $cpus $cmd"
 	else
 		perf record 'syscalls:sys_enter_*' $cpus $cmd
 		# could also pipe direct to perf script
@@ -167,7 +167,7 @@ fi
 ### execute process name mode
 tp="-e raw_syscalls:sys_enter"
 if (( write_workaround )); then
-	sh -c "perf record $tp --filter 'common_pid != '\$\$ $cpus $cmd"
+	sh -c "exec perf record $tp --filter 'common_pid != '\$\$ $cpus $cmd"
 else
 	perf record $tp $cpus $cmd
 fi


### PR DESCRIPTION
I noticed that the `write_workaround` code paths weren't working as intended (which is bad, since `perf` recording its own writes causes something of a feedback loop).

The idea behind the trick being used is that `sh` substitutes its PID for `$$`; then `exec` replaces `sh` with `perf` (keeping the same PID), so we have managed to put `perf`'s own PID in the filter, which successfully excludes `perf`'s writes.  (Yay!)

This patch just restores the `exec`s, which must have gone missing at some point, and without which we are excluding `sh`'s writes instead.