### PR TITLE
* cachestat - use date instead of printf so the command does not brak…

### DIFF
--- a/fs/cachestat
+++ b/fs/cachestat
@@ -130,7 +130,7 @@ while (( !quit && (!opt_duration || secs < duration) )); do
 	echo 1 > function_profile_enabled
 	sleep $interval
 
-	(( opt_timestamp )) && printf "%(%H:%M:%S)T " -1
+	(( opt_timestamp )) && echo -n `date +"%H:%M:%S "`
 
 	# cat both meminfo and trace stats, and let awk pick them apart
 	cat /proc/meminfo trace_stat/function* | awk -v debug=$opt_debug '


### PR DESCRIPTION
cachestat - use date instead of printf so the command does not break on RedHat 6 (at least). Before when using cachestat -t:

```
# ./cachestat  -t
Counting cache functions... Output every 1 seconds.
TIME         HITS   MISSES  DIRTIES    RATIO   BUFFERS_MB   CACHE_MB
./cachestat: line 133: printf: `(': invalid format character
     365        0        2   100.0%          302       2507
^C./cachestat: line 133: printf: `(': invalid format character
     353        0        2   100.0%          302       2507

Ending tracing...

```