### PR TITLE
modify tcpretrans script

### DIFF
--- a/net/tcpretrans
+++ b/net/tcpretrans
@@ -181,14 +181,6 @@ sub inet_h2a {
 	return join(".", @addr);
 }
 
-if ($daemon) {
-	Proc::Daemon::Init();
-	syslog('info', "start daemon mode\n");
-} else {
-	printf "%-8s %-6s %-20s -- %-20s %-12s\n", "TIME", "PID", "LADDR:LPORT",
-    "RADDR:RPORT", "STATE";
-}
-
 ### check permissions
 chdir "$tracing" or die "ERROR: accessing tracing. Root? Kernel has FTRACE?" .
     "\ndebugfs mounted? (mount -t debugfs debugfs /sys/kernel/debug)";
@@ -225,7 +217,13 @@ if ($tlp) {
 }
 map_tcp_states();
 
-
+if ($daemon) {
+	Proc::Daemon::Init();
+	syslog('info', "start daemon mode\n");
+} else {
+	printf "%-8s %-6s %-20s -- %-20s %-12s\n", "TIME", "PID", "LADDR:LPORT",
+    "RADDR:RPORT", "STATE";
+}
 
 #
 # Read and print event data. This loop waits one second then reads the buffered
@@ -234,7 +232,6 @@ map_tcp_states();
 # works because sockets that are retransmitting are usually long lived, and
 # remain in /proc/net/tcp for at least our sleep interval.
 #
-
 
 while (1) {
 	sleep $interval;

--- a/net/tcpretrans
+++ b/net/tcpretrans
@@ -62,9 +62,12 @@ use strict;
 use warnings;
 use POSIX qw(strftime);
 use Getopt::Long;
+use Sys::Syslog;
+use Proc::Daemon;
 my $tracing = "/sys/kernel/debug/tracing";
 my $flock = "/var/tmp/.ftrace-lock";
 my $interval = 1;
+my $daemon = 0;
 local $SIG{INT} = \&cleanup;
 local $SIG{QUIT} = \&cleanup;
 local $SIG{TERM} = \&cleanup;
@@ -76,7 +79,9 @@ $| = 1;
 my ($help, $stacks, $tlp);
 GetOptions("help|h"   => \$help,
 	   "stacks|s" => \$stacks,
-	   "tlp|l" => \$tlp)
+	   "tlp|l" => \$tlp,
+	   "interval|i=f" => \$interval,
+	   "d" => \$daemon)
 or usage();
 usage() if $help;
 
@@ -174,6 +179,14 @@ sub inet_h2a {
 	return join(".", @addr);
 }
 
+if ($daemon) {
+	Proc::Daemon::Init();
+	syslog('info', "start daemon mode\n");
+} else {
+	printf "%-8s %-6s %-20s -- %-20s %-12s\n", "TIME", "PID", "LADDR:LPORT",
+    "RADDR:RPORT", "STATE";
+}
+
 ### check permissions
 chdir "$tracing" or die "ERROR: accessing tracing. Root? Kernel has FTRACE?" .
     "\ndebugfs mounted? (mount -t debugfs debugfs /sys/kernel/debug)";
@@ -209,8 +222,8 @@ if ($tlp) {
 	enable_kprobe $kname_tlp or edie "ERROR: enabling $kname_tlp probe.";
 }
 map_tcp_states();
-printf "%-8s %-6s %-20s -- %-20s %-12s\n", "TIME", "PID", "LADDR:LPORT",
-    "RADDR:RPORT", "STATE";
+
+
 
 #
 # Read and print event data. This loop waits one second then reads the buffered
@@ -219,6 +232,8 @@ printf "%-8s %-6s %-20s -- %-20s %-12s\n", "TIME", "PID", "LADDR:LPORT",
 # works because sockets that are retransmitting are usually long lived, and
 # remain in /proc/net/tcp for at least our sleep interval.
 #
+
+
 while (1) {
 	sleep $interval;
 
@@ -269,9 +284,16 @@ while (1) {
 		}
 
 		my $now = strftime "%H:%M:%S", localtime;
-		printf "%-8s %-6s %-20s %s> %-20s %-12s\n", $now, $pid,
+		my $message = sprintf ("%-8s %-6s %-20s %s> %-20s %-12s\n", $now, $pid,
 		    "$laddr:$lport", $rest =~ /$kname_tlp/ ? "L" : "R",
-		    "$raddr:$rport", $state,
+		    "$raddr:$rport", $state);
+
+		if ($daemon) {
+			syslog('err', $message);
+		} else {
+			print $message;
+		}		
+
 	}
 }
 

--- a/net/tcpretrans
+++ b/net/tcpretrans
@@ -90,6 +90,8 @@ sub usage {
 	print STDERR "                  -h      # help message\n";
 	print STDERR "                  -l      # trace TCP tail loss probes\n";
 	print STDERR "                  -s      # print stack traces\n";
+	print STDERR "                  -i      # set wakeup interval by second (default 1s)\n";
+	print STDERR "                  -d      # run as daemon. messages are written by syslog\n";
 	print STDERR "   eg,\n";
 	print STDERR "       tcpretrans         # trace TCP retransmits\n";
 	exit;


### PR DESCRIPTION
I added two options in tcpretrans perl script.

1. -i 
- it's an wakeup interval. default value is 1s, but some person wants to wake up more often, set this value.

2. -d
- it's an daemonize option for script. default mode is foreground, but som person wants to run this script long period , set this value to daemonize script. and in this mode every messages are written by syslog. (/var/log/messages)