### PR TITLE
cachestat : -t option's printf code changed to date code

### DIFF
--- a/fs/cachestat
+++ b/fs/cachestat
@@ -130,7 +130,7 @@ while (( !quit && (!opt_duration || secs < duration) )); do
 	echo 1 > function_profile_enabled
 	sleep $interval
 
-	(( opt_timestamp )) && printf "%(%H:%M:%S)T " -1
+	(( opt_timestamp )) && echo -n `date "+%H:%M:%S" ` 
 
 	# cat both meminfo and trace stats, and let awk pick them apart
 	cat /proc/meminfo trace_stat/function* | awk -v debug=$opt_debug '


### PR DESCRIPTION
In centos 6.X or centos 7.x, bash version is lower than 4.2.x, so if you add option -t when use cachestat, you can see below error messages.
```
Counting cache functions... Output every 1 seconds.
TIME         HITS   MISSES  DIRTIES    RATIO   BUFFERS_MB   CACHE_MB
./cachestat: line 133: printf: `(': invalid format character
     365        0       25   100.0%          132      21138
./cachestat: line 133: printf: `(': invalid format character
     363        0       21   100.0%          132      21138
^C./cachestat: line 133: printf: `(': invalid format character
     332        0        2   100.0%          132      21138
```
So, I change printf to echo and date. To do this, error message is gone.
```
Counting cache functions... Output every 1 seconds.
TIME         HITS   MISSES  DIRTIES    RATIO   BUFFERS_MB   CACHE_MB
15:48:09     642        0       35   100.0%          132      21154
15:48:10     642        0       21   100.0%          132      21154
15:48:11     646        0       22   100.0%          132      21154
```