### PR TITLE
uprobe: set_path select library - fix #39

### DIFF
--- a/user/uprobe
+++ b/user/uprobe
@@ -156,6 +156,30 @@ function set_path {
 		fi
 	fi
 
+        # In some systems, ldconfig can return more than one library from a 
+        # given $name. Here I count them:
+        nr_libraries_in_path=$(echo $path | wc -w)
+
+        # User will be able to chose the library he wants to use.
+        # If no library is chosen, the program quits, which is the
+        # same behavior as before this patch. 
+        if [[ $nr_libraries_in_path -gt "1" ]]
+        then
+          echo "More than 1 library found. Select the library you want to use."
+          for ((i = $nr_libraries_in_path ; i > 0 ; i-- ))
+          do
+            library=$(echo $path | cut -f $i -d " ")
+            echo -n $library " use this library? [y/N]: "
+            read answer
+            if [[ $answer == "y" ]]
+            then 
+              path=$library
+              break
+            fi
+          done
+        fi
+        
+        # test if $path is executable
 	if [[ ! -x $path ]]; then
 		die "ERROR: resolved \"$name\" to \"$path\", but file missing"
 	fi


### PR DESCRIPTION
On systems with multiple libraries, running "uprobe -d 1 p:libc:gethostbyname" will fail as the program will not be able to assert the execution bit of multiple files passed as a variable.

This fix adds a prompt to the user so he/she can select the library.