### PR TITLE
Add block_bio_* tracing

### DIFF
--- a/iosnoop
+++ b/iosnoop
@@ -8,11 +8,11 @@
 # devices and their resulting performance. I/O completions can also be studied
 # event-by-event for debugging disk and controller I/O scheduling issues.
 #
-# USAGE: ./iosnoop [-hQst] [-d device] [-i iotype] [-p pid] [-n name] [duration]
+# USAGE: ./iosnoop [-BhQst] [-d device] [-i iotype] [-p pid] [-n name] [duration]
 #
 # Run "iosnoop -h" for full usage.
 #
-# REQUIREMENTS: FTRACE CONFIG, block:block_rq_* tracepoints (you may
+# REQUIREMENTS: FTRACE CONFIG, block:block_{rq,bio}_* tracepoints (you may
 # already have these on recent kernels).
 #
 # OVERHEAD: By default, iosnoop works without buffering, printing I/O events
@@ -58,13 +58,14 @@ flock=/var/tmp/.ftrace-lock
 bufsize_kb=4096
 opt_duration=0; duration=; opt_name=0; name=; opt_pid=0; pid=; ftext=
 opt_start=0; opt_end=0; opt_device=0; device=; opt_iotype=0; iotype=
-opt_queue=0
+opt_queue=0; opt_bio=0
 trap ':' INT QUIT TERM PIPE HUP	# sends execution to end tracing section
 
 function usage {
 	cat <<-END >&2
 	USAGE: iosnoop [-hQst] [-d device] [-i iotype] [-p PID] [-n name]
 	               [duration]
+	                 -B              # trace block_bio_* instead of block_rq_*
 	                 -d device       # device string (eg, "202,1)
 	                 -i iotype       # match type (eg, '*R*' for all reads)
 	                 -n name         # process name to match on I/O issue
@@ -100,10 +101,10 @@ function end {
 	echo "Ending tracing..." 2>/dev/null
 	cd $tracing
 	warn "echo 0 > events/block/$b_start/enable"
-	warn "echo 0 > events/block/block_rq_complete/enable"
+	warn "echo 0 > events/block/$b_end/enable"
 	if (( opt_device || opt_iotype || opt_pid )); then
 		warn "echo 0 > events/block/$b_start/filter"
-		warn "echo 0 > events/block/block_rq_complete/filter"
+		warn "echo 0 > events/block/$b_end/filter"
 	fi
 	warn "echo > trace"
 	(( wroteflock )) && warn "rm $flock"
@@ -123,9 +124,10 @@ function edie {
 }
 
 ### process options
-while getopts d:hi:n:p:Qst opt
+while getopts Bd:hi:n:p:Qst opt
 do
 	case $opt in
+	B)	opt_bio=1 ;;
 	d)	opt_device=1; device=$OPTARG ;;
 	i)	opt_iotype=1; iotype=$OPTARG ;;
 	n)	opt_name=1; name=$OPTARG ;;
@@ -150,6 +152,7 @@ fi
 
 ### option logic
 (( opt_pid && opt_name )) && die "ERROR: use either -p or -n."
+(( opt_bio && opt_queue )) && die "ERROR: -B and -Q are mutually exclusive."
 (( opt_pid )) && ftext=" issued by PID $pid"
 (( opt_name )) && ftext=" issued by process name \"$name\""
 if (( opt_duration )); then
@@ -157,10 +160,15 @@ if (( opt_duration )); then
 else
 	echo "Tracing block I/O$ftext. Ctrl-C to end."
 fi
-if (( opt_queue )); then
+if (( opt_bio )); then
+	b_start=block_bio_queue
+	b_end=block_bio_complete
+elif (( opt_queue )); then
 	b_start=block_rq_insert
+	b_end=block_rq_complete
 else
 	b_start=block_rq_issue
+	b_end=block_rq_complete
 fi
 
 ### select awk
@@ -195,13 +203,13 @@ if (( opt_pid )); then
 fi
 if (( opt_iotype || opt_device || opt_pid )); then
 	if ! echo "$filter_i" > events/block/$b_start/filter || \
-	    ! echo "$filter" > events/block/block_rq_complete/filter
+	    ! echo "$filter" > events/block/$b_end/filter
 	then
 		edie "ERROR: setting -d or -t filter. Exiting."
 	fi
 fi
 if ! echo 1 > events/block/$b_start/enable || \
-    ! echo 1 > events/block/block_rq_complete/enable; then
+    ! echo 1 > events/block/$b_end/enable; then
 	edie "ERROR: enabling block I/O tracepoints. Exiting."
 fi
 (( opt_start )) && printf "%-15s " "STARTs"
@@ -247,7 +255,8 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
 		if (opt_name && match(comm, name) == 0)
 			next
 		#
-		# example: (fields1..4+o) 202,1 W 0 () 12862264 + 8 [tar]
+		# block_rq_  example: (fields1..4+o) 202,1 W 0 () 12862264 + 8 [tar]
+		# block_bio_ example: (fields1..4+o) 202,1 W      12862264 + 2048 [ext4lazyinit]
 		# The cmd field "()" might contain multiple words (hex),
 		# hence stepping from the right (NF-3).
 		#
@@ -259,10 +268,10 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
 	}
 
 	# block I/O completion
-	$1 != "#" && $0 ~ /rq_complete/ {
+	$1 != "#" && $0 ~ /block_(rq|bio)_complete/ {
 		#
-		# example: (fields1..4+o) 202,1 W () 12862256 + 8 [0]
-		#
+		# block_rq_complete  example: (fields1..4+o) 202,1 W () 12862256 + 8 [0]
+		# block_bio_complete example: (fields1..4+o) 202,1 W    12862256 + 2048 [0]
 		dir = $(6+o)
 		loc = $(NF-3)
 		nsec = $(NF-1)

--- a/man/man8/iosnoop.8
+++ b/man/man8/iosnoop.8
@@ -3,7 +3,7 @@
 iosnoop \- trace block I/O events as they occur. Uses Linux ftrace.
 .SH SYNOPSIS
 .B iosnoop
-[\-hQst] [\-d device] [\-i iotype] [\-p pid] [\-n name] [duration]
+[\-BhQst] [\-d device] [\-i iotype] [\-p pid] [\-n name] [duration]
 .SH DESCRIPTION
 iosnoop prints block device I/O events as they happen, with useful details such
 as PID, device, I/O type, block number, I/O size, and latency.
@@ -20,9 +20,14 @@ section in OPTIONS.
 Since this uses ftrace, only the root user can use this tool.
 .SH REQUIREMENTS
 FTRACE CONFIG, and the tracepoints block:block_rq_insert, block:block_rq_issue,
-and block:block_rq_complete, which you may already have enabled and available on
-recent Linux kernels. And awk.
+block:block_rq_complete, block:block_bio_queue, and block:block_bio_complete
+which you may already have enabled and available on recent Linux kernels. And awk.
 .SH OPTIONS
+.TP
+\-B
+Trache block:block_bio_queue and block:block_bio_completete, not block_rq_*.
+This is useful for tracing events such as ext4lazyinit. This option is mutually
+exclusive with -Q.
 .TP
 \-d device
 Only show I/O issued by this device. (eg, "202,1"). This matches the DEV


### PR DESCRIPTION
Disclaimer: I don't necessarily need it merged as-is, but it may be helpful for others who stumble upon a similar problem.

I scratched my head today trying to explain the IO on a disk, as it wasn't showing up in `iosnoop` output in a manner that would allow me to pinpoint what exactly is that IO.

So I hacked in tracing `block_bio_queue` and `block_bio_complete`, et voila
```
COMM         PID    TYPE DEV      BLOCK        BYTES     LATms
ext4lazyinit 13030  W    253,18   5553305856   1048576     3.31
ext4lazyinit 13030  WS   253,18   5553307904   1048576     5.70
ext4lazyinit 13030  WS   253,23   1778432256   1048576     5.70
ext4lazyinit 13030  W    253,18   5553309952   1048576     6.61
```

This patch adds `-B` option that traces `block_bio_queue` and `block_bio_complete` instead of `block_rq_*`, and is mutually exclusive with `-Q`.
