### PR TITLE
uprobe: Enhance the 'check command deps' code to check all dependenci…

### DIFF
--- a/user/uprobe
+++ b/user/uprobe
@@ -241,12 +241,18 @@ END
 	exit
 fi
 
-### check command dependencies
+### check command/utility dependencies
+needinstall=0
 for cmd in file objdump ldconfig awk; do
-	which $cmd > /dev/null
-	(( $? != 0 )) && die "ERROR: missing $cmd in \$PATH. $0 needs" \
-	    "to use this command. Exiting."
+    which $cmd > /dev/null 2>&1 || {
+        [ ${needinstall} -eq 0 ] && echo "[!] $0: missing utilit[y|ies]:"
+        echo " ${cmd}"
+        needinstall=1
+        continue
+   }
 done
+[ ${needinstall} -eq 1 ] && die "ERROR: missing one or more utils (see above) in \$PATH. $0 needs" \
+    "to use these command(s). Pl install and retry, exiting."
 
 ### option logic
 [[ "$uprobe" == "" ]] && usage

--- a/user/uprobe
+++ b/user/uprobe
@@ -241,18 +241,13 @@ END
 	exit
 fi
 
-### check command/utility dependencies
+### check command dependencies
 needinstall=0
 for cmd in file objdump ldconfig awk; do
-    which $cmd > /dev/null 2>&1 || {
-        [ ${needinstall} -eq 0 ] && echo "[!] $0: missing utilit[y|ies]:"
-        echo " ${cmd}"
-        needinstall=1
-        continue
-   }
+    which $cmd > /dev/null
+	(( $? != 0 )) && die "ERROR: missing $cmd in \$PATH. $0 needs" \
+	    "to use this command. Exiting."
 done
-[ ${needinstall} -eq 1 ] && die "ERROR: missing one or more utils (see above) in \$PATH. $0 needs" \
-    "to use these command(s). Pl install and retry, exiting."
 
 ### option logic
 [[ "$uprobe" == "" ]] && usage


### PR DESCRIPTION
The way the script currently works, if, say, 2 utils (objdump and awk) are not installed/missing, the script would first exit saying that 'objdump' is missing. On install of objdump by the end-user and a rerun, it would then crib about 'awk' missing; why twice (or more)!? 

This commit checks all dependency commands/utilities at one shot, and reports the ones that are missing at once, so that the end-user can install all and then retry.