### PR TITLE
Add useful options to funcgraph (-I -F) and functrace (-s)

### DIFF
--- a/kernel/funcgraph
+++ b/kernel/funcgraph
@@ -78,6 +78,8 @@ function usage {
 	USAGE: funcgraph [-aCDhHPtT] [-m maxdepth] [-p PID] [-L TID] [-d secs] funcstring
 	                 -a              # all info (same as -HPt)
 	                 -C              # measure on-CPU time only
+	                 -I              # do not trace functions that happen inside interrupt
+	                 -F              # only record function whenever the duration is greater than given (in µs)
 	                 -d seconds      # trace duration, and use buffers
 	                 -D              # do not show function duration
 	                 -h              # this usage message
@@ -117,6 +119,8 @@ function end {
 	(( opt_tail )) && warn "echo nofuncgraph-tail > trace_options"
 	(( opt_nodur )) && warn "echo funcgraph-duration > trace_options"
 	(( opt_cpu )) && warn "echo sleep-time > trace_options"
+	(( opt_irqs )) && warn "echo funcgraph-irqs > trace_options"
+	(( opt_func_duration )) && warn "echo 0 > tracing_thresh"
 
 	warn "echo nop > current_tracer"
 	(( opt_pid || opt_tid )) && warn "echo > set_ftrace_pid"
@@ -141,11 +145,13 @@ function edie {
 }
 
 ### process options
-while getopts aCd:DhHm:p:L:PtT opt
+while getopts aCIF:d:DhHm:p:L:PtT opt
 do
 	case $opt in
 	a)	opt_headers=1; opt_proc=1; opt_time=1 ;;
 	C)	opt_cpu=1; ;;
+	I)	opt_irqs=1; ;;
+	F)	opt_func_duration=1; func_duration=$OPTARG ;;
 	d)	opt_duration=1; duration=$OPTARG ;;
 	D)	opt_nodur=1; ;;
 	m)	opt_max=1; max=$OPTARG ;;
@@ -216,6 +222,16 @@ fi
 if (( opt_cpu )); then
 	if ! echo nosleep-time > trace_options; then
 		edie "ERROR: setting -C (nosleep-time). Exiting."
+	fi
+fi
+if (( opt_irqs )); then
+	if ! echo nofuncgraph-irqs > trace_options; then
+		edie "ERROR: setting -I (nofuncgraph-irqs). Old kernel? Exiting."
+	fi
+fi
+if (( opt_func_duration )); then
+	if ! echo $func_duration > tracing_thresh; then
+		edie "ERROR: setting -F (tracing_thresh). Old kernel? Exiting."
 	fi
 fi
 # the following must be done after setting current_tracer

--- a/kernel/functrace
+++ b/kernel/functrace
@@ -71,6 +71,7 @@ function usage {
 	                 -H              # include column headers
 	                 -p PID          # trace when this pid is on-CPU
 	                 -L TID          # trace when this thread is on-CPU
+	                 -s              # show kernel stack traces
 	  eg,
 	       functrace do_nanosleep    # trace the do_nanosleep() function
 	       functrace '*sleep'        # trace functions ending in "sleep"
@@ -96,6 +97,7 @@ function end {
 	cd $tracing
 	warn "echo nop > current_tracer"
 	(( opt_pid || opt_tid )) && warn "echo > set_ftrace_pid"
+	(( opt_stack )) && warn "echo 0 > options/func_stack_trace"
 	warn "echo > set_ftrace_filter"
 	warn "echo > trace"
 	(( wroteflock )) && warn "rm $flock"
@@ -115,13 +117,14 @@ function edie {
 }
 
 ### process options
-while getopts d:hHp:L: opt
+while getopts d:hHp:L:s opt
 do
 	case $opt in
 	d)	opt_duration=1; duration=$OPTARG ;;
 	p)	opt_pid=1; pid=$OPTARG ;;
 	L)	opt_tid=1; tid=$OPTARG ;;
 	H)	opt_headers=1; ;;
+	s)	opt_stack=1 ;;
 	h|?)	usage ;;
 	esac
 done
@@ -165,6 +168,11 @@ if (( opt_tid )); then
     if ! echo $tid > set_ftrace_pid; then
         edie "ERROR: setting -L $tid (TID exist?). Exiting."
     fi
+fi
+if (( opt_stack )); then
+	if ! echo 1 > options/func_stack_trace; then
+		edie "ERROR: enabling stack traces (-s). Exiting"
+	fi
 fi
 if ! echo "$funcs" > set_ftrace_filter; then
 	edie "ERROR: enabling \"$funcs\". Exiting."


### PR DESCRIPTION
funcgraph:
-I do not trace functions that happen inside interrupt
-F only record function whenever the duration is greater than given (in µs)

functrace :
-s show kernel stack traces