### PR TITLE
execsnoop: ensure tracing_on is enabled during execution

### DIFF
--- a/execsnoop
+++ b/execsnoop
@@ -91,6 +91,7 @@ function end {
 	echo 2>/dev/null
 	echo "Ending tracing..." 2>/dev/null
 	cd $tracing
+	warn "echo 0 > tracing_on"
 	warn "echo 0 > events/kprobes/$kname/enable"
 	warn "echo 0 > events/sched/sched_process_fork/enable"
 	warn "echo -:$kname >> kprobe_events"
@@ -197,6 +198,9 @@ if ! echo $kprobe >> kprobe_events 2>/dev/null; then
 		    edie "ERROR: adding a kprobe for execve. Exiting."
         fi
 	fi
+fi
+if ! echo 1 > tracing_on; then
+	edie "ERROR: enabling tracing. Exiting."
 fi
 if ! echo 1 > events/kprobes/$kname/enable; then
 	edie "ERROR: enabling kprobe for execve. Exiting."


### PR DESCRIPTION
Huge fan here! your tools are so useful and I learn a lot from the code itself so thanks for making them and putting them here for all of us to enjoy.

This is just a small adjustment to set tracing_on to 1 (and disable it when done) in `execsnoop`, perhaps there was a good reason not to have this in place, but this helped me get some results :smile: 

if this is not a good idea, maybe a note of this in the help section/README.

fixes https://github.com/brendangregg/perf-tools/issues/29

