### PR TITLE
Fixes #74 - mawk cannot do the three-argument form of match()

### DIFF
--- a/opensnoop
+++ b/opensnoop
@@ -238,8 +238,9 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
 		#
 		# eg: ... (do_sys_open+0xc3/0x220 <- getname) arg1="file1"
 		#
-		match($0, /arg1=\"(.+)\"/, m)
-		lastfile[pid] = m[1]
+		# avoiding match groups for mawk compatability
+		match($0, /arg1=\".+\"/)
+		lastfile[pid] = substr($0, RSTART + 6, RLENGTH - 7)
 	}
 
 	# sys_open()


### PR DESCRIPTION
This makes admittedly clumsy use of substr() to avoid being dependent on the three-argument form of match() which is only supported by gawk.