### PR TITLE
Fixes #81 - When the kernel informs us of LOST EVENTS, clear lastfile

### DIFF
--- a/opensnoop
+++ b/opensnoop
@@ -245,6 +245,8 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
 	# sys_open()
 	$1 != "#" && $(4+o) == "sys_open" {
 		filename = lastfile[pid]
+		if (!filename)
+			next
 		delete lastfile[pid]
 		if (opt_file && filename !~ file)
 			next
@@ -262,7 +264,9 @@ fi ) | $awk -v o=$offset -v opt_name=$opt_name -v name=$name \
 		printf "%-16.16s %-6s %4s %s\n", comm, pid, rval, filename
 	}
 
-	$0 ~ /LOST.*EVENTS/ { print "WARNING: " $0 > "/dev/stderr" }
+	$0 ~ /LOST.*EVENTS/ {
+		delete lastfile
+		print "WARNING: " $0 > "/dev/stderr" }
 '
 
 ### end tracing


### PR DESCRIPTION
Correlating two lines seperated by a gulf of lost events results in
spurious output, for example a open that was attempted on a non-existing
file, but which seems to have resulted in a valid returncode.