### PR TITLE
Check tracing dir and add alternate one if usual debugfs one isn't mounted

### DIFF
--- a/kernel/kprobe
+++ b/kernel/kprobe
@@ -194,6 +194,21 @@ if (( debug )); then
 	echo "kname: $kname, kprobe: $kprobe"
 fi
 
+# It's possible - esp on a production kernel - that CONFIG_DEBUG_FS_DISALLOW_MOUNT=y
+# which implies that though the debugfs filesystem's APIs are available, the
+# fs itself isn't mounted - it's invisible. Take this into account, else the script
+# won't work on such systems
+if [ ! -d ${tracing} ]; then
+   if [ -d /sys/kernel/tracing ]; then
+      tracing=/sys/kernel/tracing
+   else
+      die "ISSUE: neither the /sys/kernel/debug/tracing nor /sys/kernel/tracing dir is available"
+   fi  
+fi
+if (( debug )); then
+    echo "tracing dir: ${tracing}"
+fi
+
 ### check permissions
 cd $tracing || die "ERROR: accessing tracing. Root user? Kernel has FTRACE?
     debugfs mounted? (mount -t debugfs debugfs /sys/kernel/debug)"

--- a/user/uprobe
+++ b/user/uprobe
@@ -242,9 +242,8 @@ END
 fi
 
 ### check command dependencies
-needinstall=0
 for cmd in file objdump ldconfig awk; do
-    which $cmd > /dev/null
+	which $cmd > /dev/null
 	(( $? != 0 )) && die "ERROR: missing $cmd in \$PATH. $0 needs" \
 	    "to use this command. Exiting."
 done

--- a/user/uprobe
+++ b/user/uprobe
@@ -241,12 +241,18 @@ END
 	exit
 fi
 
-### check command dependencies
+### check command/utility dependencies
+needinstall=0
 for cmd in file objdump ldconfig awk; do
-	which $cmd > /dev/null
-	(( $? != 0 )) && die "ERROR: missing $cmd in \$PATH. $0 needs" \
-	    "to use this command. Exiting."
+    which $cmd > /dev/null 2>&1 || {
+        [ ${needinstall} -eq 0 ] && echo "[!] $0: missing utilit[y|ies]:"
+        echo " ${cmd}"
+        needinstall=1
+        continue
+   }
 done
+[ ${needinstall} -eq 1 ] && die "ERROR: missing one or more utils (see above) in \$PATH. $0 needs" \
+    "to use these command(s). Pl install and retry, exiting."
 
 ### option logic
 [[ "$uprobe" == "" ]] && usage

--- a/user/uprobe
+++ b/user/uprobe
@@ -241,18 +241,13 @@ END
 	exit
 fi
 
-### check command/utility dependencies
+### check command dependencies
 needinstall=0
 for cmd in file objdump ldconfig awk; do
-    which $cmd > /dev/null 2>&1 || {
-        [ ${needinstall} -eq 0 ] && echo "[!] $0: missing utilit[y|ies]:"
-        echo " ${cmd}"
-        needinstall=1
-        continue
-   }
+    which $cmd > /dev/null
+	(( $? != 0 )) && die "ERROR: missing $cmd in \$PATH. $0 needs" \
+	    "to use this command. Exiting."
 done
-[ ${needinstall} -eq 1 ] && die "ERROR: missing one or more utils (see above) in \$PATH. $0 needs" \
-    "to use these command(s). Pl install and retry, exiting."
 
 ### option logic
 [[ "$uprobe" == "" ]] && usage


### PR DESCRIPTION
As per Issue #108 
 kprobe: fails when debugfs isn't mounted, use alternate