### PR TITLE
funccount: support counting multiple functions

### DIFF
--- a/examples/funccount_example.txt
+++ b/examples/funccount_example.txt
@@ -110,7 +110,7 @@ rate, and can begin researching them from the source code.
 Use -h to print the USAGE message:
 
 # ./funccount -h
-USAGE: funccount [-hT] [-i secs] [-d secs] [-t top] funcstring
+USAGE: funccount [-hT] [-i secs] [-d secs] [-t top] funcstring [funcstring ...]
                  -d seconds      # total duration of trace
                  -h              # this usage message
                  -i seconds      # interval summary

--- a/kernel/funccount
+++ b/kernel/funccount
@@ -6,7 +6,7 @@
 # This is a proof of concept using Linux ftrace capabilities on older kernels,
 # and works by using function profiling: in-kernel counters.
 #
-# USAGE: funccount [-hT] [-i secs] [-d secs] [-t top] funcstring
+# USAGE: funccount [-hT] [-i secs] [-d secs] [-t top] funcstring [funcstring ...]
 #    eg,
 #        funccount 'ext3*'	# count all ext3* kernel function calls
 #
@@ -47,7 +47,7 @@ trap 'quit=1' INT QUIT TERM PIPE HUP	# sends execution to end tracing section
 
 function usage {
 	cat <<-END >&2
-	USAGE: funccount [-hT] [-i secs] [-d secs] [-t top] funcstring
+	USAGE: funccount [-hT] [-i secs] [-d secs] [-t top] funcstring [funcstring ...]
 	                 -d seconds      # total duration of trace
 	                 -h              # this usage message
 	                 -i seconds      # interval summary
@@ -91,7 +91,7 @@ shift $(( $OPTIND - 1 ))
 
 ### option logic
 (( $# == 0 )) && usage
-funcs="$1"
+funcs="${@:1}"
 if (( opt_tail )); then
 	tcmd="tail -$tnum"
 	ttext=" Top $tnum only."

--- a/man/man8/funccount.8
+++ b/man/man8/funccount.8
@@ -3,7 +3,7 @@
 funccount \- count kernel function calls matching specified wildcards. Uses Linux ftrace.
 .SH SYNOPSIS
 .B funccount
-[\-hT] [\-i secs] [\-d secs] [\-t top] funcstring
+[\-hT] [\-i secs] [\-d secs] [\-t top] funcstring [funcstring ...]
 .SH DESCRIPTION
 This tool is a quick way to determine which kernel functions are being called,
 and at what rate. It uses ftrace function profiling capabilities.


### PR DESCRIPTION
funccount did not support tracing multiple functions, unless they could
be globed with '*'.

This could also not be achieved with parallel processes because they
would compete for set_ftrace_filter.